### PR TITLE
Implement transaction button logic

### DIFF
--- a/src/__tests__/explorer.test.ts
+++ b/src/__tests__/explorer.test.ts
@@ -1,0 +1,31 @@
+/**
+ * Tests for Stellar explorer URL generation
+ */
+
+import { describe, it, expect } from 'vitest';
+import { getTransactionExplorerUrl, getAccountExplorerUrl } from '@/lib/explorer';
+
+describe('Stellar Explorer URLs', () => {
+  const mockTxHash = 'abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890';
+  const mockAddress = 'GD5XQKZLQNXJY5L7F5RQ5Y7K2M3N4O5P6Q7R8S9T0U1V2W3X4Y5Z6';
+
+  it('should generate correct transaction explorer URL for public network', () => {
+    const url = getTransactionExplorerUrl(mockTxHash, 1);
+    expect(url).toBe('https://steexp.com/tx/abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890');
+  });
+
+  it('should generate correct account explorer URL for public network', () => {
+    const url = getAccountExplorerUrl(mockAddress, 1);
+    expect(url).toBe('https://steexp.com/account/GD5XQKZLQNXJY5L7F5RQ5Y7K2M3N4O5P6Q7R8S9T0U1V2W3X4Y5Z6');
+  });
+
+  it('should default to public network when no network specified', () => {
+    const url = getTransactionExplorerUrl(mockTxHash);
+    expect(url).toBe('https://steexp.com/tx/abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890');
+  });
+
+  it('should handle unknown network by falling back to public network', () => {
+    const url = getTransactionExplorerUrl(mockTxHash, 999);
+    expect(url).toBe('https://steexp.com/tx/abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890');
+  });
+});

--- a/src/components/transactions/transaction-item.tsx
+++ b/src/components/transactions/transaction-item.tsx
@@ -3,6 +3,7 @@
 import React from 'react';
 import { Copy, ExternalLink, RotateCcw } from 'lucide-react';
 import { Button } from '@/components/ui/button';
+import { openTransactionInExplorer } from '@/lib/explorer';
 
 export interface TransactionItemProps {
   type: 'verification' | 'stake' | 'withdrawal' | 'dispute';
@@ -143,6 +144,7 @@ export function TransactionItem({
             size="sm"
             className="h-6 w-6 p-0 hover:bg-slate-700"
             title="View on explorer"
+            onClick={() => openTransactionInExplorer(hash)}
           >
             <ExternalLink className="w-4 h-4 text-slate-400" />
           </Button>

--- a/src/lib/explorer.ts
+++ b/src/lib/explorer.ts
@@ -1,0 +1,53 @@
+/**
+ * Stellar blockchain explorer utilities
+ */
+
+export interface ExplorerConfig {
+  name: string;
+  baseUrl: string;
+  transactionPath: string;
+}
+
+// Stellar explorer configurations
+export const STELLAR_EXPLORERS: Record<number, ExplorerConfig> = {
+  // Stellar Public Network
+  1: {
+    name: 'Stellar Expert',
+    baseUrl: 'https://steexp.com',
+    transactionPath: '/tx',
+  },
+  // Stellar Testnet
+  // Note: Stellar testnet uses the same explorer but different URL
+};
+
+/**
+ * Get the appropriate explorer URL for a transaction hash
+ * @param txHash - Transaction hash
+ * @param network - Network ID (defaults to 1 for public network)
+ * @returns Full explorer URL for the transaction
+ */
+export function getTransactionExplorerUrl(txHash: string, network: number = 1): string {
+  const explorer = STELLAR_EXPLORERS[network] || STELLAR_EXPLORERS[1];
+  return `${explorer.baseUrl}${explorer.transactionPath}/${txHash}`;
+}
+
+/**
+ * Get the appropriate explorer URL for an account address
+ * @param address - Stellar account address
+ * @param network - Network ID (defaults to 1 for public network)
+ * @returns Full explorer URL for the account
+ */
+export function getAccountExplorerUrl(address: string, network: number = 1): string {
+  const explorer = STELLAR_EXPLORERS[network] || STELLAR_EXPLORERS[1];
+  return `${explorer.baseUrl}/account/${address}`;
+}
+
+/**
+ * Opens a transaction in a new browser tab
+ * @param txHash - Transaction hash
+ * @param network - Network ID (optional)
+ */
+export function openTransactionInExplorer(txHash: string, network?: number): void {
+  const url = getTransactionExplorerUrl(txHash, network);
+  window.open(url, '_blank', 'noopener,noreferrer');
+}


### PR DESCRIPTION
Summary
Problem: The transaction verification button in the TransactionItem component had no functionality - it rendered but had no href or onClick handler, preventing users from verifying transactions.

Solution Implemented:

Created Stellar Explorer Utility (src/lib/explorer.ts):
Added STELLAR_EXPLORERS configuration for different networks
Implemented getTransactionExplorerUrl() function to generate proper URLs
Implemented openTransactionInExplorer() function with proper noopener,noreferrer attributes
Added support for account explorer URLs as well
Fixed TransactionItem Component (src/components/transactions/transaction-item.tsx):
Added import for the explorer utility
Added onClick={() => openTransactionInExplorer(hash)} to the explorer button
The button now properly opens Stellar Expert explorer in a new tab
Added Tests (src/__tests__/explorer.test.ts):
Created unit tests to verify URL generation works correctly
Tests cover public network, default network, and fallback scenarios

closes #88 