### PR TITLE
feat(WalletConnection): use aria-live for copy feedback

### DIFF
--- a/src/components/WalletConnection.tsx
+++ b/src/components/WalletConnection.tsx
@@ -1,29 +1,44 @@
+import { useRef } from 'react'
 import { useAccount, useDisconnect } from '@/hooks/useAccount'
 import { useIsMounted } from '@/hooks/useIsMounted'
 import { ConnectButton } from '@/components/ui/ConnectButton'
 import styles from './style.module.css'
+
+const COPY_STATUS_CLEAR_MS = 2000
 
 // TODO: Eliminate flash of unconnected content on loading
 export function WalletConnection() {
   const mounted = useIsMounted()
   const account = useAccount()
   const disconnect = useDisconnect()
+  const copyStatusRef = useRef<HTMLSpanElement>(null)
+  const clearTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null)
 
   const handleDisconnect = async () => {
     await disconnect()
   }
 
-  const handleCopyAddress = () => {
-    if (account?.address) {
-      navigator.clipboard.writeText(account.address)
-      alert('Address copied to clipboard')
+  const announceCopy = (message: string) => {
+    const node = copyStatusRef.current
+    if (!node) return
+    node.textContent = message
+    if (clearTimeoutRef.current) {
+      clearTimeout(clearTimeoutRef.current)
     }
+    clearTimeoutRef.current = setTimeout(() => {
+      if (copyStatusRef.current) {
+        copyStatusRef.current.textContent = ''
+      }
+    }, COPY_STATUS_CLEAR_MS)
   }
 
-  const handleKeyDown = (e: React.KeyboardEvent) => {
-    if (e.key === 'Enter' || e.key === ' ') {
-      e.preventDefault()
-      handleCopyAddress()
+  const handleCopyAddress = async () => {
+    if (!account?.address) return
+    try {
+      await navigator.clipboard.writeText(account.address)
+      announceCopy('Address copied to clipboard')
+    } catch {
+      announceCopy('Failed to copy address')
     }
   }
 
@@ -35,16 +50,19 @@ export function WalletConnection() {
       <button
         type="button"
         className={styles.card}
-        onClick={() => {
-          navigator.clipboard.writeText(account.address);
-        }}
+        onClick={handleCopyAddress}
         aria-label={`Copy wallet address ${account.displayName}`}
       >
         {account.displayName}
       </button>
 
       {/* Screen-reader feedback (instead of alert) */}
-      <span className="sr-only" aria-live="polite" id="copy-status" />
+      <span
+        ref={copyStatusRef}
+        className="sr-only"
+        aria-live="polite"
+        id="copy-status"
+      />
 
       {/* Disconnect button (already good, just improve semantics) */}
       <button


### PR DESCRIPTION
Resolves #100.

`WalletConnection` used `alert('Address copied to clipboard')` to confirm a successful wallet-address copy. `alert()` blocks the UI, breaks keyboard flow, and is poor accessibility — and the existing `<span id="copy-status" aria-live="polite">` placeholder was never populated.

## Change

Wire the existing aria-live region to the clipboard write:

- `handleCopyAddress` writes text content into the aria-live span via a ref and clears it after 2 s.
- The address button calls `handleCopyAddress` directly so success and failure both announce, replacing the inline call site that was bypassing the helper.
- A failed clipboard write announces `Failed to copy address` rather than swallowing the error.
- The unused `handleKeyDown` helper is removed; the existing `aria-label` on the address button provides the same affordance and a native `<button>` already responds to Enter / Space.

## Acceptance criteria

- [x] No `alert()` in `WalletConnection.tsx`.
- [x] Live region announces status on copy success and failure.
- [x] Copy still works (the address button now calls `handleCopyAddress`).