### PR TITLE
fix(claim-submission): enable Enter key submission and add regression…

### DIFF
--- a/src/__tests__/integration/claim-submission.test.tsx
+++ b/src/__tests__/integration/claim-submission.test.tsx
@@ -193,6 +193,36 @@ describe('Claim Submission Integration Tests', () => {
       expect(onSubmit).toHaveBeenCalledWith(mockClaim)
     })
 
+    it('should submit the form when pressing Enter inside a text field', async () => {
+      const { submitClaim } = require('@/app/api/claims.api')
+      const mockClaim = createMockClaim({ title: 'Enter Key Claim', status: 'OPEN' })
+      submitClaim.mockResolvedValue(mockClaim)
+
+      const onSubmit = jest.fn()
+
+      render(<ClaimSubmissionForm onSubmit={onSubmit} onClose={jest.fn()} />, { queryClient })
+
+      const titleInput = screen.getByPlaceholderText('Title')
+      const categoryInput = screen.getByPlaceholderText('Category')
+      const impactInput = screen.getByPlaceholderText('Impact')
+      const sourceInput = screen.getByPlaceholderText('Source')
+      const descriptionInput = screen.getByPlaceholderText('Description')
+
+      await user.type(titleInput, 'Enter Key Claim')
+      await user.type(categoryInput, 'fraud')
+      await user.type(impactInput, 'High Impact')
+      await user.type(sourceInput, 'https://example.com')
+      await user.type(descriptionInput, 'This description is long enough to pass validation.')
+
+      await user.type(titleInput, '{Enter}')
+
+      await waitFor(() => {
+        expect(onSubmit).toHaveBeenCalledWith(
+          expect.objectContaining({ title: 'Enter Key Claim' })
+        )
+      })
+    })
+
     it('should show loading state during submission', async () => {
       const { submitClaim } = require('@/app/api/claims.api')
       submitClaim.mockImplementation(

--- a/src/components/features/claim-submission/ClaimSubmissionForm.tsx
+++ b/src/components/features/claim-submission/ClaimSubmissionForm.tsx
@@ -168,6 +168,9 @@ const ClaimSubmissionForm: React.FC<ClaimFormProps> = ({ onSubmit, onClose }) =>
         {["title", "category", "impact", "source"].map((field) => (
           <div key={field}>
             <input
+              id={`claim-${field}`}
+              name={field}
+              type="text"
               className={`input ${errors[field] ? "border-red-500" : ""}`}
               placeholder={capitalize(field)}
               value={
@@ -194,6 +197,8 @@ const ClaimSubmissionForm: React.FC<ClaimFormProps> = ({ onSubmit, onClose }) =>
         ))}
 
         <textarea
+          id="claim-description"
+          name="description"
           placeholder="Description"
           value={description}
           onChange={(e) =>


### PR DESCRIPTION
Close #167 

## PR Description

### Summary
Add Enter-key form submission support for the claim submission modal and add regression coverage.

### What changed
- Updated ClaimSubmissionForm.tsx
  - Added explicit `id`, `name`, and `type="text"` attributes to claim input fields
  - Added `id="claim-description"` and `name="description"` to the description textarea
- Added regression test in claim-submission.test.tsx
  - `should submit the form when pressing Enter inside a text field`

### Why
This fixes an accessibility/usability issue where the claim submission modal did not reliably submit when the user pressed Enter inside a form field. The explicit form field attributes help ensure correct native form behavior.

### Testing
Run:
```bash
pnpm exec jest src/__tests__/integration/claim-submission.test.tsx --runInBand
```

---
