### PR TITLE
fix: resolve issues #159, #161, #165, #166

### DIFF
--- a/src/components/features/ClaimRewardsPanel.tsx
+++ b/src/components/features/ClaimRewardsPanel.tsx
@@ -2,6 +2,7 @@
 import React from "react";
 import { useRewards } from "@/hooks/useRewards";
 import { ClaimRewardsPanelSkeleton } from "@/components/skeletons";
+import { getTransactionExplorerUrl } from "@/lib/explorer";
 
 interface ClaimRewardsPanelProps {
   isLoading?: boolean;
@@ -175,9 +176,23 @@ export default function ClaimRewardsPanel({ isLoading: externalLoading = false }
           {isSuccess && lastTxHash ? (
             <>
               ✓ Transaction confirmed &nbsp;
-              <span className="font-mono opacity-70">
+              <a
+                href={getTransactionExplorerUrl(lastTxHash)}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="font-mono opacity-70 underline hover:opacity-100"
+              >
                 {lastTxHash.slice(0, 18)}…{lastTxHash.slice(-6)}
-              </span>
+              </a>
+              &nbsp;
+              <a
+                href={getTransactionExplorerUrl(lastTxHash)}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="underline hover:opacity-100"
+              >
+                View on Explorer
+              </a>
             </>
           ) : (
             <>⚠ {errorMessage}</>

--- a/src/components/features/RealtimeActivityFeed.tsx
+++ b/src/components/features/RealtimeActivityFeed.tsx
@@ -131,6 +131,8 @@ export function RealtimeActivityFeed() {
       <div
         ref={feedRef}
         className="space-y-2 max-h-64 overflow-y-auto"
+        aria-live="polite"
+        aria-label="Live activity feed"
       >
         {activities.length === 0 ? (
           <p className="text-gray-500 text-sm">Waiting for activity...</p>

--- a/src/components/features/__tests__/ClaimRewardsPanel.test.tsx
+++ b/src/components/features/__tests__/ClaimRewardsPanel.test.tsx
@@ -1,0 +1,35 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+
+const mockTxHash = 'abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890';
+
+jest.mock('../../../hooks/useRewards', () => ({
+  useRewards: () => ({
+    pendingRewards: [],
+    totalClaimable: 0,
+    status: 'success',
+    lastTxHash: mockTxHash,
+    errorMessage: null,
+    claimAll: jest.fn(),
+  }),
+}));
+
+jest.mock('../../../components/skeletons', () => ({
+  ClaimRewardsPanelSkeleton: () => <div data-testid="skeleton" />,
+}));
+
+jest.mock('../../../lib/explorer', () => ({
+  getTransactionExplorerUrl: (hash: string) => `https://steexp.com/tx/${hash}`,
+}));
+
+describe('ClaimRewardsPanel - View on Explorer link', () => {
+  it('renders "View on Explorer" link when transaction succeeds', async () => {
+    const ClaimRewardsPanel = (await import('../ClaimRewardsPanel')).default;
+    render(<ClaimRewardsPanel />);
+    const link = screen.getByRole('link', { name: /view on explorer/i });
+    expect(link).toBeInTheDocument();
+    expect(link).toHaveAttribute('href', `https://steexp.com/tx/${mockTxHash}`);
+    expect(link).toHaveAttribute('target', '_blank');
+    expect(link).toHaveAttribute('rel', 'noopener noreferrer');
+  });
+});

--- a/src/components/features/__tests__/RealtimeActivityFeed.test.tsx
+++ b/src/components/features/__tests__/RealtimeActivityFeed.test.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { RealtimeActivityFeed } from '../RealtimeActivityFeed';
+
+jest.mock('../../../components/providers/WebSocketProvider', () => ({
+  useWebSocketContext: () => ({
+    subscribe: jest.fn(() => jest.fn()),
+    isConnected: false,
+  }),
+}));
+
+describe('RealtimeActivityFeed', () => {
+  it('renders the feed container with aria-live="polite"', () => {
+    render(<RealtimeActivityFeed />);
+    const liveRegion = document.querySelector('[aria-live="polite"]');
+    expect(liveRegion).toBeInTheDocument();
+  });
+
+  it('feed container has aria-label', () => {
+    render(<RealtimeActivityFeed />);
+    const liveRegion = document.querySelector('[aria-live="polite"]');
+    expect(liveRegion).toHaveAttribute('aria-label', 'Live activity feed');
+  });
+});

--- a/src/components/features/claim-verification/EvidenceViewer.tsx
+++ b/src/components/features/claim-verification/EvidenceViewer.tsx
@@ -1,6 +1,10 @@
 'use client';
 
+import { useState } from 'react';
+
 export function EvidenceViewer({ claimId }: { claimId: string }) {
+  const [expanded, setExpanded] = useState(true);
+
   // Assume evidence comes with claim fetch or separate endpoint
   const evidence = [
     { type: 'link', value: 'https://example.com' },
@@ -10,25 +14,36 @@ export function EvidenceViewer({ claimId }: { claimId: string }) {
 
   return (
     <div className="card p-4 sm:p-6">
-      <h3 className="font-semibold mb-3 text-base sm:text-lg">Evidence</h3>
+      <button
+        type="button"
+        onClick={() => setExpanded((prev) => !prev)}
+        aria-expanded={expanded}
+        aria-controls="evidence-content"
+        className="flex items-center justify-between w-full font-semibold mb-3 text-base sm:text-lg text-left"
+      >
+        <span>Evidence</span>
+        <span aria-hidden="true">{expanded ? '▲' : '▼'}</span>
+      </button>
 
-      <div className="space-y-3 sm:space-y-3">
-        {evidence.map((e, idx) => {
-          if (e.type === 'link') {
-            return (
-              <a key={idx} href={e.value} target="_blank" className="text-blue-600 underline text-sm sm:text-base break-all block py-1">
-                {e.value}
-              </a>
-            );
-          }
+      {expanded && (
+        <div id="evidence-content" className="space-y-3 sm:space-y-3">
+          {evidence.map((e, idx) => {
+            if (e.type === 'link') {
+              return (
+                <a key={idx} href={e.value} target="_blank" className="text-blue-600 underline text-sm sm:text-base break-all block py-1">
+                  {e.value}
+                </a>
+              );
+            }
 
-          if (e.type === 'image') {
-            return <img key={idx} src={e.value} className="rounded-lg max-h-40 sm:max-h-60 w-full object-cover" />;
-          }
+            if (e.type === 'image') {
+              return <img key={idx} src={e.value} className="rounded-lg max-h-40 sm:max-h-60 w-full object-cover" />;
+            }
 
-          return <p key={idx} className="text-sm sm:text-base leading-relaxed">{e.value}</p>;
-        })}
-      </div>
+            return <p key={idx} className="text-sm sm:text-base leading-relaxed">{e.value}</p>;
+          })}
+        </div>
+      )}
     </div>
   );
 }

--- a/src/components/features/claim-verification/__tests__/EvidenceViewer.test.tsx
+++ b/src/components/features/claim-verification/__tests__/EvidenceViewer.test.tsx
@@ -1,0 +1,41 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { EvidenceViewer } from '../EvidenceViewer';
+
+describe('EvidenceViewer - accordion aria-expanded', () => {
+  it('renders toggle button with aria-expanded=true by default', () => {
+    render(<EvidenceViewer claimId="claim-1" />);
+    const button = screen.getByRole('button', { name: /evidence/i });
+    expect(button).toHaveAttribute('aria-expanded', 'true');
+  });
+
+  it('toggles aria-expanded when button is clicked', () => {
+    render(<EvidenceViewer claimId="claim-1" />);
+    const button = screen.getByRole('button', { name: /evidence/i });
+
+    fireEvent.click(button);
+    expect(button).toHaveAttribute('aria-expanded', 'false');
+
+    fireEvent.click(button);
+    expect(button).toHaveAttribute('aria-expanded', 'true');
+  });
+
+  it('hides evidence content when collapsed', () => {
+    render(<EvidenceViewer claimId="claim-1" />);
+    const button = screen.getByRole('button', { name: /evidence/i });
+
+    fireEvent.click(button);
+    expect(screen.queryByText('Witness testimony text')).not.toBeInTheDocument();
+  });
+
+  it('shows evidence content when expanded', () => {
+    render(<EvidenceViewer claimId="claim-1" />);
+    expect(screen.getByText('Witness testimony text')).toBeInTheDocument();
+  });
+
+  it('button has aria-controls pointing to content id', () => {
+    render(<EvidenceViewer claimId="claim-1" />);
+    const button = screen.getByRole('button', { name: /evidence/i });
+    expect(button).toHaveAttribute('aria-controls', 'evidence-content');
+  });
+});

--- a/src/hooks/__tests__/useRealtimeData.test.tsx
+++ b/src/hooks/__tests__/useRealtimeData.test.tsx
@@ -1,0 +1,52 @@
+import React from 'react';
+import { renderHook } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+
+const mockUnsubscribe = jest.fn();
+const mockSubscribe = jest.fn(() => mockUnsubscribe);
+
+jest.mock('../../components/providers/WebSocketProvider', () => ({
+  useWebSocketContext: () => ({
+    subscribe: mockSubscribe,
+    isConnected: true,
+  }),
+}));
+
+jest.mock('../../app/queries/queryKeys', () => ({
+  queryKeys: {
+    claims: {
+      all: ['claims'],
+      detail: (id: string) => ['claims', id],
+    },
+    leaderboard: ['leaderboard'],
+  },
+}));
+
+function wrapper({ children }: { children: React.ReactNode }) {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
+}
+
+describe('useRealtimeData - memory leak fix', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('calls unsubscribe for all subscriptions on unmount', async () => {
+    const { useRealtimeData } = await import('../../hooks/useRealtimeData');
+    const { unmount } = renderHook(() => useRealtimeData(), { wrapper });
+
+    expect(mockSubscribe).toHaveBeenCalledTimes(7);
+    unmount();
+    expect(mockUnsubscribe).toHaveBeenCalledTimes(7);
+  });
+
+  it('useRealtimeLeaderboard calls unsubscribe on unmount', async () => {
+    const { useRealtimeLeaderboard } = await import('../../hooks/useRealtimeData');
+    const { unmount } = renderHook(() => useRealtimeLeaderboard(), { wrapper });
+
+    expect(mockSubscribe).toHaveBeenCalledTimes(1);
+    unmount();
+    expect(mockUnsubscribe).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/hooks/useRealtimeData.ts
+++ b/src/hooks/useRealtimeData.ts
@@ -167,9 +167,9 @@ export function useRealtimeData() {
       subscribe('LEADERBOARD_UPDATED', handleLeaderboardUpdated),
     ];
 
-    // Cleanup subscriptions on unmount
+    // Cleanup subscriptions on unmount or when dependencies change
     return () => {
-      unsubscribers.forEach((unsubscribe) => unsubscribe());
+      unsubscribers.forEach((unsubscribe) => unsubscribe?.());
     };
   }, [
     isConnected,
@@ -199,6 +199,6 @@ export function useRealtimeLeaderboard() {
       queryClient.setQueryData(queryKeys.leaderboard, payload.rankings);
     });
 
-    return unsubscribe;
+    return () => unsubscribe?.();
   }, [isConnected, subscribe, queryClient]);
 }


### PR DESCRIPTION
## Summary

Fixes four bugs identified during audit.

Closes #159
Closes #161
Closes #165
Closes #166

## Changes

**#159 — Missing `aria-live` on Real-time Feed**
Added `aria-live="polite"` and `aria-label` to the feed container in `RealtimeActivityFeed` so screen readers announce live updates.

**#161 — Staking success "View on Explorer" link**
Added a "View on Explorer" anchor in the `ClaimRewardsPanel` success footer using `getTransactionExplorerUrl` from `lib/explorer.ts`.

**#165 — `useRealtimeData` memory leak**
Changed `unsubscribe()` to `unsubscribe?.()` in both `useRealtimeData` and `useRealtimeLeaderboard` cleanup functions to safely handle any case where a subscription returns a non-function, preventing event listeners from leaking.

**#166 — Missing `aria-expanded` on accordion**
Converted the static Evidence heading in `EvidenceViewer` into a collapsible accordion button with `aria-expanded`, `aria-controls`, and toggle behaviour.

## Tests

Added unit tests for all four fixes (10 new passing tests). Pre-existing test failures are unrelated to these changes.