### PR TITLE
Feat/issues185

### DIFF
--- a/src/components/features/claim-submission/ClaimSubmissionForm.tsx
+++ b/src/components/features/claim-submission/ClaimSubmissionForm.tsx
@@ -198,7 +198,7 @@ const ClaimSubmissionForm: React.FC<ClaimFormProps> = ({ onSubmit, onClose }) =>
         )}
 
         {submitError && (
-          <p className="text-red-500 text-sm" role="alert">
+          <p className="text-red-500 text-sm break-words" role="alert">
             {submitError}
           </p>
         )}
@@ -229,7 +229,7 @@ const ClaimSubmissionForm: React.FC<ClaimFormProps> = ({ onSubmit, onClose }) =>
               }
             />
             {errors[field as keyof FormErrors] && touched[field] && (
-              <p className="text-red-500 text-sm">{errors[field as keyof FormErrors]}</p>
+              <p className="text-red-500 text-sm break-words">{errors[field as keyof FormErrors]}</p>
             )}
           </div>
         ))}
@@ -246,7 +246,7 @@ const ClaimSubmissionForm: React.FC<ClaimFormProps> = ({ onSubmit, onClose }) =>
         />
 
         {errors.description && touched.description && (
-          <p className="text-red-500 text-sm">{errors.description}</p>
+          <p className="text-red-500 text-sm break-words">{errors.description}</p>
         )}
 
         <div className="flex gap-3 mt-4">

--- a/src/components/reputation/BadgeTooltip.tsx
+++ b/src/components/reputation/BadgeTooltip.tsx
@@ -14,7 +14,7 @@ export default function BadgeTooltip({ tier, score, children }: Props) {
     <div className="relative group inline-block">
       {children}
 
-      <div className="absolute bottom-full mb-2 hidden group-hover:block w-48 bg-black text-white text-xs p-2 rounded shadow-lg">
+      <div className="absolute bottom-full mb-2 hidden group-hover:block w-48 bg-black text-white text-xs p-2 rounded shadow-lg z-50">
         <p className="font-semibold">{tier.toUpperCase()} Tier</p>
         <p>Reputation Score: {score}</p>
         <p>Higher tiers unlock trust benefits.</p>

--- a/src/components/transactions/transaction-item.tsx
+++ b/src/components/transactions/transaction-item.tsx
@@ -120,7 +120,7 @@ export function TransactionItem({
       {errorMessage && (
         <div className="mb-4 p-3 bg-red-500/10 border border-red-500/30 rounded flex items-start gap-2">
           <span className="text-red-400 mt-0.5">⚠️</span>
-          <p className="text-sm text-red-400">{errorMessage}</p>
+          <p className="text-sm text-red-400 break-words">{errorMessage}</p>
         </div>
       )}
 


### PR DESCRIPTION
Closes #184

fix: tooltip z-index and error message truncation

## Changes
- Add missing z-index to BadgeTooltip component tooltip display
- Add word-wrap to error messages in ClaimSubmissionForm and transaction-item to prevent truncation

## Details
- **Tooltip z-index**: Added \`z-50\` class to BadgeTooltip tooltip to ensure proper layering and visibility
- **Error message handling**: Applied \`break-words\` utility class to error messages ensuring they wrap instead of overflow on small screens"

Closes #185