### PR TITLE
fix(ui): improve ThemeToggle icon contrast

### DIFF
--- a/src/__tests__/components/theme-toggle-contrast.test.tsx
+++ b/src/__tests__/components/theme-toggle-contrast.test.tsx
@@ -1,0 +1,54 @@
+/**
+ * ThemeToggle icon contrast invariants
+ *
+ * Audit finding: #197 - ThemeToggle icon contrast
+ *
+ * Invariants enforced:
+ *   - Button uses theme-aware background classes (not hardcoded dark bg).
+ *   - Button has accessible aria-label.
+ *   - Icons have aria-hidden to avoid duplicate announcements.
+ */
+
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { ThemeToggle } from '@/components/ui/ThemeToggle';
+
+jest.mock('@/components/providers/ThemeProvider', () => ({
+  useTheme: () => ({
+    theme: 'light',
+    resolvedTheme: 'light',
+    setTheme: jest.fn(),
+    toggleTheme: jest.fn(),
+  }),
+}));
+
+describe('ThemeToggle — icon contrast', () => {
+  it('renders a button with an accessible aria-label', () => {
+    render(<ThemeToggle />);
+    const btn = screen.getByRole('button');
+    expect(btn).toHaveAttribute('aria-label');
+    expect(btn.getAttribute('aria-label')).toMatch(/toggle theme/i);
+  });
+
+  it('does not use hardcoded dark background class', () => {
+    render(<ThemeToggle />);
+    const btn = screen.getByRole('button');
+    expect(btn.className).not.toContain('bg-[#232329]');
+  });
+
+  it('uses theme-aware background classes for light mode', () => {
+    render(<ThemeToggle />);
+    const btn = screen.getByRole('button');
+    expect(btn.className).toMatch(/bg-gray-100/);
+    expect(btn.className).toMatch(/dark:bg-gray-800/);
+  });
+
+  it('icons are hidden from assistive technology', () => {
+    render(<ThemeToggle />);
+    const btn = screen.getByRole('button');
+    const svgs = btn.querySelectorAll('svg');
+    svgs.forEach((svg) => {
+      expect(svg).toHaveAttribute('aria-hidden', 'true');
+    });
+  });
+});

--- a/src/components/ui/ThemeToggle.tsx
+++ b/src/components/ui/ThemeToggle.tsx
@@ -28,12 +28,12 @@ export function ThemeToggle({ className = '', showLabel = false }: ThemeTogglePr
 
   const getIcon = () => {
     if (theme === 'system') {
-      return <Monitor className="w-4 h-4" />;
+      return <Monitor className="w-4 h-4" aria-hidden="true" />;
     }
     if (theme === 'light') {
-      return <Sun className="w-4 h-4" />;
+      return <Sun className="w-4 h-4" aria-hidden="true" />;
     }
-    return <Moon className="w-4 h-4" />;
+    return <Moon className="w-4 h-4" aria-hidden="true" />;
   };
 
   const getLabel = () => {
@@ -51,7 +51,10 @@ export function ThemeToggle({ className = '', showLabel = false }: ThemeTogglePr
   return (
     <button
       onClick={handleToggle}
-      className={`flex items-center gap-2 px-3 py-1.5 rounded-md bg-[#232329] hover:bg-[#2a2a32] text-white transition-colors ${className}`}
+      className={`flex items-center gap-2 px-3 py-1.5 rounded-md
+        bg-gray-100 hover:bg-gray-200 text-gray-800
+        dark:bg-gray-800 dark:hover:bg-gray-700 dark:text-gray-100
+        transition-colors ${className}`}
       title={`Theme: ${theme} (click to change)`}
       aria-label={`Toggle theme (current: ${theme})`}
     >


### PR DESCRIPTION
## Summary

Fixes the ThemeToggle icon contrast issue by replacing the hardcoded g-[#232329] background with theme-aware Tailwind utility classes.

### Changes
- src/components/ui/ThemeToggle.tsx: replaced hardcoded dark background with g-gray-100 dark:bg-gray-800 and matching hover/text colors for proper contrast in both light and dark modes; added ria-hidden to icons
- src/__tests__/components/theme-toggle-contrast.test.tsx: added invariant tests verifying no hardcoded bg, theme-aware classes present, and icons are hidden from assistive technology

closes #197