### PR TITLE
feat: implement dynamic category icon mapping and unit tests

### DIFF
--- a/src/components/features/ActiveClaimsTable.tsx
+++ b/src/components/features/ActiveClaimsTable.tsx
@@ -1,6 +1,7 @@
 import React, { useRef, useState } from "react";
 import { activeClaims } from "@/data/mock-data";
 import { ActiveClaimsTableSkeleton } from "@/components/skeletons";
+import { getCategoryIcon } from "@/lib/category-icons";
 
 interface ActiveClaimsTableProps {
   isLoading?: boolean;
@@ -88,15 +89,21 @@ const ActiveClaimsTable = ({ isLoading = false }: ActiveClaimsTableProps) => {
           </tr>
         </thead>
         <tbody>
-          {activeClaims.map((claim, idx) => (
-            <tr key={idx} className="border-b border-[#232329] hover:bg-[#232329]/40">
-              <td className="py-3">
-                <div className="flex flex-col">
-                  <span className="text-xs text-[#5b5bf6] font-semibold">{claim.category} <span className="ml-2 bg-[#232329] text-[#5b5bf6] px-2 py-0.5 rounded-full text-[10px]">{claim.impact}</span></span>
-                  <span className="text-white font-medium leading-tight">{claim.title}</span>
-                  <span className="text-xs text-[#a1a1aa]">{claim.source}</span>
-                </div>
-              </td>
+          {activeClaims.map((claim, idx) => {
+            const CategoryIcon = getCategoryIcon(claim.category);
+            return (
+              <tr key={idx} className="border-b border-[#232329] hover:bg-[#232329]/40">
+                <td className="py-3">
+                  <div className="flex flex-col">
+                    <span className="text-xs text-[#5b5bf6] font-semibold flex items-center gap-1.5">
+                      <CategoryIcon size={14} />
+                      {claim.category} 
+                      <span className="ml-2 bg-[#232329] text-[#5b5bf6] px-2 py-0.5 rounded-full text-[10px]">{claim.impact}</span>
+                    </span>
+                    <span className="text-white font-medium leading-tight">{claim.title}</span>
+                    <span className="text-xs text-[#a1a1aa]">{claim.source}</span>
+                  </div>
+                </td>
               <td className="py-3">
                 <span className={claim.status === "Verified" ? "text-green-400" : claim.status === "Under Review" ? "text-yellow-400" : "text-red-400"}>{claim.status}</span>
               </td>
@@ -112,7 +119,7 @@ const ActiveClaimsTable = ({ isLoading = false }: ActiveClaimsTableProps) => {
                 </button>
               </td>
             </tr>
-          ))}
+          )})}
         </tbody>
       </table>
     </div>

--- a/src/components/features/claim-details/ClaimStats.tsx
+++ b/src/components/features/claim-details/ClaimStats.tsx
@@ -1,7 +1,9 @@
 import { ClaimData } from "@/app/types/dispute";
-import { CheckCircle2, FileText, Shield } from "lucide-react";
+import { CheckCircle2, Shield } from "lucide-react";
+import { getCategoryIcon } from "@/lib/category-icons";
 
 export const ClaimStats = ({ data }: { data: ClaimData }) => {
+  const CategoryIcon = getCategoryIcon(data.category);
   return (
     <div className="bg-[#13141b] border border-gray-800 rounded-xl p-6 mb-6">
       <h2 className="text-white font-semibold mb-6">Claim Stats</h2>
@@ -15,7 +17,7 @@ export const ClaimStats = ({ data }: { data: ClaimData }) => {
           <span className="text-sm font-medium text-white">{data.verifiersCount}</span>
         </div>
         <div className="flex justify-between items-center">
-          <span className="text-sm text-gray-400 flex items-center"><FileText size={16} className="mr-2" /> Category</span>
+          <span className="text-sm text-gray-400 flex items-center"><CategoryIcon size={16} className="mr-2" /> Category</span>
           <span className="text-xs font-medium text-white bg-gray-800 px-3 py-1 rounded-md">{data.category}</span>
         </div>
       </div>

--- a/src/lib/__tests__/category-icons.test.tsx
+++ b/src/lib/__tests__/category-icons.test.tsx
@@ -1,0 +1,37 @@
+import { getCategoryIcon, CATEGORY_ICON_MAP } from '../category-icons';
+import { 
+  Cloud, 
+  Activity, 
+  Cpu, 
+  AlertCircle, 
+  AlertTriangle, 
+  Globe, 
+  FileText 
+} from "lucide-react";
+
+describe('category-icons utility', () => {
+  it('should return correct icons for known categories', () => {
+    expect(getCategoryIcon('Climate')).toBe(Cloud);
+    expect(getCategoryIcon('climate')).toBe(Cloud);
+    expect(getCategoryIcon(' CLIMATE ')).toBe(Cloud);
+    expect(getCategoryIcon('Health')).toBe(Activity);
+    expect(getCategoryIcon('Technology')).toBe(Cpu);
+    expect(getCategoryIcon('Misinformation')).toBe(AlertCircle);
+    expect(getCategoryIcon('Fraud')).toBe(AlertTriangle);
+    expect(getCategoryIcon('Politics')).toBe(Globe);
+  });
+
+  it('should return FileText for unknown categories', () => {
+    expect(getCategoryIcon('Unknown')).toBe(FileText);
+    expect(getCategoryIcon('')).toBe(FileText);
+  });
+
+  it('should have all categories in CATEGORY_ICON_MAP mapped correctly', () => {
+    expect(CATEGORY_ICON_MAP['Climate']).toBe(Cloud);
+    expect(CATEGORY_ICON_MAP['Health']).toBe(Activity);
+    expect(CATEGORY_ICON_MAP['Technology']).toBe(Cpu);
+    expect(CATEGORY_ICON_MAP['Misinformation']).toBe(AlertCircle);
+    expect(CATEGORY_ICON_MAP['Fraud']).toBe(AlertTriangle);
+    expect(CATEGORY_ICON_MAP['Politics']).toBe(Globe);
+  });
+});

--- a/src/lib/category-icons.tsx
+++ b/src/lib/category-icons.tsx
@@ -1,0 +1,29 @@
+import { 
+  Cloud, 
+  Activity, 
+  Cpu, 
+  AlertCircle, 
+  AlertTriangle, 
+  Globe, 
+  FileText,
+  type LucideIcon 
+} from "lucide-react";
+
+export const CATEGORY_ICON_MAP: Record<string, LucideIcon> = {
+  Climate: Cloud,
+  Health: Activity,
+  Technology: Cpu,
+  Misinformation: AlertCircle,
+  Fraud: AlertTriangle,
+  Politics: Globe,
+};
+
+export function getCategoryIcon(category: string): LucideIcon {
+  if (!category) return FileText;
+  
+  // Normalize category name: trim and capitalize first letter
+  const normalized = category.trim();
+  const capitalized = normalized.charAt(0).toUpperCase() + normalized.slice(1).toLowerCase();
+  
+  return CATEGORY_ICON_MAP[capitalized] || CATEGORY_ICON_MAP[normalized] || FileText;
+}


### PR DESCRIPTION
closes #177 

### **Title: Refine and implement: Incorrect category icon mapping**

### **Description**
This PR addresses the incorrect category icon mapping identified during the audit (Internal Ref #FE-177). It replaces hardcoded icons with a centralized, dynamic mapping system that supports various claim categories and includes a robust fallback mechanism.

### **Changes**
- **Centralized Mapping Utility**: Created [category-icons.tsx](file:///c:/Users/yunus/Desktop/truthbounty-frontend/src/lib/category-icons.tsx) to manage the association between categories and Lucide icons.
- **Dynamic Icon Retrieval**: Implemented `getCategoryIcon` with normalization logic (case-insensitive, trimming) to ensure reliable matching.
- **UI Integration**:
    - Updated [ActiveClaimsTable.tsx](file:///c:/Users/yunus/Desktop/truthbounty-frontend/src/components/features/ActiveClaimsTable.tsx) to display category-specific icons in the main feed.
    - Updated [ClaimStats.tsx](file:///c:/Users/yunus/Desktop/truthbounty-frontend/src/components/features/claim-details/ClaimStats.tsx) to replace generic icons with specific ones in the claim detail view.
- **Unit Testing**: Added [category-icons.test.tsx](file:///c:/Users/yunus/Desktop/truthbounty-frontend/src/lib/__tests__/category-icons.test.tsx) to verify mapping accuracy, normalization, and fallback behavior.

### **Mapped Categories**
| Category | Icon |
| :--- | :--- |
| **Climate** | `Cloud` |
| **Health** | `Activity` |
| **Technology** | `Cpu` |
| **Misinformation** | `AlertCircle` |
| **Fraud** | `AlertTriangle` |
| **Politics** | `Globe` |
| **Others (Fallback)** | `FileText` |

### **Verification & Testing**
- **Unit Tests**: All tests passed, covering exact matches, case variations, and empty inputs.
- **UI/UX**: Verified that icons render correctly across different components without regressions.
- **Integrity**: Ensured no impact on the underlying data structures or protocol invariants.