### PR TITLE
Fix/trust localstorage override regression

### DIFF
--- a/src/components/hooks/__tests__/useTrust.test.ts
+++ b/src/components/hooks/__tests__/useTrust.test.ts
@@ -1,5 +1,5 @@
 import { renderHook, waitFor } from "@testing-library/react";
-import { useTrust } from "../useTrust";
+import { useTrust, useTrustForAddress } from "../useTrust";
 
 jest.mock("@/hooks/useAccount", () => ({
   useAccount: jest.fn(),
@@ -55,6 +55,38 @@ describe("useTrust", () => {
       expect(typeof result.current.reputation).toBe("number");
       expect(typeof result.current.accountAgeDays).toBe("number");
       expect(typeof result.current.suspicious).toBe("boolean");
+    });
+  });
+
+  it("does not leak current-user overrides into address-specific trust lookups", async () => {
+    localStorage.setItem(
+      "trustInfo",
+      JSON.stringify({
+        reputation: 15,
+        isVerified: false,
+      }),
+    );
+
+    const { result, rerender } = renderHook(
+      ({ address }: { address?: string }) => useTrustForAddress(address),
+      { initialProps: { address: undefined } },
+    );
+
+    await waitFor(() => {
+      expect(result.current.reputation).toBe(15);
+      expect(result.current.isVerified).toBe(false);
+    });
+
+    rerender({ address: "0xdef" });
+
+    await waitFor(() => {
+      const expectedReputation = Array.from("0xdef").reduce(
+        (sum, character) => sum + character.charCodeAt(0),
+        0,
+      ) % 101;
+
+      expect(result.current.reputation).toBe(expectedReputation);
+      expect(result.current.isVerified).toBe(true);
     });
   });
 });

--- a/src/components/hooks/useTrust.ts
+++ b/src/components/hooks/useTrust.ts
@@ -78,6 +78,8 @@ export function useTrustForAddress(address?: string): TrustInfo {
   useEffect(() => {
     if (!address) {
       setOverrideInfo(parseTrustInfoFromStorage());
+    } else {
+      setOverrideInfo(null);
     }
   }, [address]);
 


### PR DESCRIPTION
Summary
Fix trust override handling so values stored in localStorage for the current user no longer leak into address-specific trust lookups.

What changed
Updated the trust hook to clear current-user override state when a specific address is requested.
Added a regression test to ensure address-based trust calculations continue to use their own derived values instead of the current-user override.
Why
The previous behavior could incorrectly apply the localStorage override to other address-based trust views, which made the demo override behave inconsistently.


closes #168 