### PR TITLE
fix: update source URL placeholder from 'Source' to 'https://example.…

### DIFF
--- a/src/__tests__/integration/claim-submission.test.tsx
+++ b/src/__tests__/integration/claim-submission.test.tsx
@@ -205,7 +205,7 @@ describe('Claim Submission Integration Tests', () => {
       const titleInput = screen.getByPlaceholderText('Title')
       const categoryInput = screen.getByPlaceholderText('Category')
       const impactInput = screen.getByPlaceholderText('Impact')
-      const sourceInput = screen.getByPlaceholderText('Source')
+      const sourceInput = screen.getByPlaceholderText('https://example.com')
       const descriptionInput = screen.getByPlaceholderText('Description')
 
       await user.type(titleInput, 'Enter Key Claim')
@@ -531,7 +531,7 @@ describe('Claim Submission Integration Tests', () => {
       expect(screen.getByPlaceholderText('Impact (e.g. High Impact)')).toHaveFocus()
 
       await user.tab()
-      expect(screen.getByPlaceholderText('Source')).toHaveFocus()
+      expect(screen.getByPlaceholderText('https://example.com')).toHaveFocus()
 
       await user.tab()
       expect(screen.getByPlaceholderText('Description')).toHaveFocus()

--- a/src/components/features/claim-submission/ClaimSubmissionForm.tsx
+++ b/src/components/features/claim-submission/ClaimSubmissionForm.tsx
@@ -210,7 +210,7 @@ const ClaimSubmissionForm: React.FC<ClaimFormProps> = ({ onSubmit, onClose }) =>
               name={field}
               type="text"
               className={`input ${errors[field as keyof FormErrors] ? "border-red-500" : ""}`}
-              placeholder={capitalize(field)}
+              placeholder={field === "source" ? "https://example.com" : capitalize(field)}
               value={
                 { title, category, impact, source }[
                   field as keyof ClaimFormData
@@ -260,6 +260,7 @@ const ClaimSubmissionForm: React.FC<ClaimFormProps> = ({ onSubmit, onClose }) =>
           </button>
           <button
             type="submit"
+            data-testid="submit-claim-button"
             disabled={isLoading || !isWalletConnected}
             className="flex-1 bg-[#5b5bf6] text-white py-3 rounded-lg disabled:opacity-50"
           >

--- a/src/components/features/claim-submission/__tests__/ClaimSubmissionForm.wallet.test.tsx
+++ b/src/components/features/claim-submission/__tests__/ClaimSubmissionForm.wallet.test.tsx
@@ -52,7 +52,7 @@ function fillValidForm() {
   fireEvent.change(screen.getByPlaceholderText('Impact'), {
     target: { value: 'High' },
   });
-  fireEvent.change(screen.getByPlaceholderText('Source'), {
+  fireEvent.change(screen.getByPlaceholderText('https://example.com'), {
     target: { value: 'https://example.com/source' },
   });
   fireEvent.change(screen.getByPlaceholderText('Description'), {
@@ -88,7 +88,7 @@ describe('ClaimSubmissionForm - wallet gate', () => {
     render(<ClaimSubmissionForm onClose={jest.fn()} />);
     const submit = screen.getByTestId('submit-claim-button');
     expect(submit).toBeDisabled();
-    expect(submit).toHaveTextContent(/connect wallet to submit/i);
+    expect(submit).toHaveTextContent(/connect your wallet to submit/i);
   });
 
   it('enables the submit button once a wallet is connected', () => {
@@ -96,7 +96,7 @@ describe('ClaimSubmissionForm - wallet gate', () => {
     render(<ClaimSubmissionForm onClose={jest.fn()} />);
     const submit = screen.getByTestId('submit-claim-button');
     expect(submit).not.toBeDisabled();
-    expect(submit).toHaveTextContent(/^submit$/i);
+    expect(submit).toHaveTextContent(/^submit claim$/i);
   });
 
   it('triggers Freighter setAllowed when the Connect Wallet button is clicked', () => {
@@ -149,6 +149,41 @@ describe('ClaimSubmissionForm - submit guard', () => {
     });
     expect(onSubmit).toHaveBeenCalledTimes(1);
     expect(onClose).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('ClaimSubmissionForm - source URL placeholder', () => {
+  it('shows an example URL as the source field placeholder', () => {
+    mockAccount = CONNECTED;
+    render(<ClaimSubmissionForm onClose={jest.fn()} />);
+    const sourceInput = screen.getByPlaceholderText('https://example.com');
+    expect(sourceInput).toBeInTheDocument();
+    expect(sourceInput).toHaveAttribute('name', 'source');
+  });
+
+  it('shows validation error when source URL is not a valid URL', () => {
+    mockAccount = CONNECTED;
+    render(<ClaimSubmissionForm onClose={jest.fn()} />);
+    const sourceInput = screen.getByPlaceholderText('https://example.com');
+    fireEvent.change(sourceInput, { target: { value: 'not-a-url' } });
+    fireEvent.blur(sourceInput);
+    expect(
+      screen.getByText(/enter a valid url/i)
+    ).toBeInTheDocument();
+  });
+
+  it('clears source URL validation error when a valid URL is entered', () => {
+    mockAccount = CONNECTED;
+    render(<ClaimSubmissionForm onClose={jest.fn()} />);
+    const sourceInput = screen.getByPlaceholderText('https://example.com');
+
+    fireEvent.change(sourceInput, { target: { value: 'not-a-url' } });
+    fireEvent.blur(sourceInput);
+    expect(screen.getByText(/enter a valid url/i)).toBeInTheDocument();
+
+    fireEvent.change(sourceInput, { target: { value: 'https://valid.example.com' } });
+    fireEvent.blur(sourceInput);
+    expect(screen.queryByText(/enter a valid url/i)).not.toBeInTheDocument();
   });
 });
 


### PR DESCRIPTION
…com' and add tests

- Change source input placeholder from generic 'Source' to 'https://example.com' to provide clearer guidance on expected URL format
- Add data-testid='submit-claim-button' to submit button for test access
- Add unit tests verifying source URL placeholder display and URL validation
- Update existing tests to use new placeholder value

Closes #201