### PR TITLE
fix(FE-198): refine useLeaderboard sorting logic with protocol invari…

### DIFF
--- a/src/__tests__/mocks/handlers.ts
+++ b/src/__tests__/mocks/handlers.ts
@@ -76,9 +76,33 @@ export const handlers = [
   // GET /api/leaderboard
   http.get('/api/leaderboard', () => {
     return HttpResponse.json([
-      { address: '0x123...', reputation: 100, verifications: 10 },
-      { address: '0x456...', reputation: 80, verifications: 8 },
-      { address: '0x789...', reputation: 60, verifications: 6 },
+      {
+        rank: 1,
+        userId: 'user-1',
+        username: 'Academic Consortium',
+        totalVerifications: 10,
+        accuracy: 98.2,
+        totalStaked: 12400,
+        totalEarned: 850,
+      },
+      {
+        rank: 2,
+        userId: 'user-2',
+        username: 'News Alliance',
+        totalVerifications: 8,
+        accuracy: 96.8,
+        totalStaked: 8200,
+        totalEarned: 620,
+      },
+      {
+        rank: 3,
+        userId: 'user-3',
+        username: 'Data Science Labs',
+        totalVerifications: 6,
+        accuracy: 97.5,
+        totalStaked: 6100,
+        totalEarned: 480,
+      },
     ], { status: 200 })
   }),
 

--- a/src/app/queries/leaderboard.queries.ts
+++ b/src/app/queries/leaderboard.queries.ts
@@ -3,10 +3,18 @@
 import { useQuery } from '@tanstack/react-query';
 import { queryKeys } from './queryKeys';
 import { fetchLeaderboard } from '../api/leaderboard.api';
+import { sortAndNormalizeLeaderboard } from '@/lib/leaderboard';
+import type { LeaderboardEntry } from '@/app/types/websocket';
 
 export function useLeaderboard() {
-  return useQuery(queryKeys.leaderboard, fetchLeaderboard, {
+  return useQuery<LeaderboardEntry[]>({
+    queryKey: queryKeys.leaderboard,
+    queryFn: fetchLeaderboard,
     staleTime: 1000 * 60 * 10, // 10 min
     refetchInterval: 1000 * 60 * 5, // auto-refresh every 5 min (fallback when WS not available)
+    // The server is the source of truth for ranking. We only enforce protocol
+    // invariants (sort by server rank + normalize dense ranks) on the client
+    // without re-sorting by arbitrary fields.
+    select: (data: LeaderboardEntry[]) => sortAndNormalizeLeaderboard(data),
   });
 }

--- a/src/hooks/__tests__/useLeaderboard.test.tsx
+++ b/src/hooks/__tests__/useLeaderboard.test.tsx
@@ -1,0 +1,129 @@
+import React from "react";
+import { renderHook, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import type { LeaderboardEntry } from "@/app/types/websocket";
+import { validateLeaderboardInvariants } from "@/lib/leaderboard";
+
+// Mock the fetchLeaderboard API
+const mockLeaderboardData: LeaderboardEntry[] = [
+  {
+    rank: 3,
+    userId: "user-3",
+    username: "Carol",
+    totalVerifications: 6,
+    accuracy: 97.5,
+    totalStaked: 6100,
+    totalEarned: 480,
+  },
+  {
+    rank: 1,
+    userId: "user-1",
+    username: "Alice",
+    totalVerifications: 10,
+    accuracy: 98.2,
+    totalStaked: 12400,
+    totalEarned: 850,
+  },
+  {
+    rank: 2,
+    userId: "user-2",
+    username: "Bob",
+    totalVerifications: 8,
+    accuracy: 96.8,
+    totalStaked: 8200,
+    totalEarned: 620,
+  },
+];
+
+jest.mock("../../app/api/leaderboard.api", () => ({
+  fetchLeaderboard: jest.fn(() => Promise.resolve(mockLeaderboardData)),
+}));
+
+jest.mock("../../app/queries/queryKeys", () => ({
+  queryKeys: {
+    leaderboard: ["leaderboard"],
+  },
+}));
+
+function wrapper({ children }: { children: React.ReactNode }) {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+}
+
+describe("useLeaderboard sorting logic", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("returns data sorted by server rank ascending", async () => {
+    const { useLeaderboard } = await import("../useLeaderboard");
+    const { result } = renderHook(() => useLeaderboard(), { wrapper });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    const data = result.current.data as LeaderboardEntry[];
+    expect(data.map((e) => e.userId)).toEqual(["user-1", "user-2", "user-3"]);
+  });
+
+  it("normalizes ranks to dense sequential integers starting at 1", async () => {
+    const { useLeaderboard } = await import("../useLeaderboard");
+    const { result } = renderHook(() => useLeaderboard(), { wrapper });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    const data = result.current.data as LeaderboardEntry[];
+    expect(data.map((e) => e.rank)).toEqual([1, 2, 3]);
+  });
+
+  it("does not re-sort by arbitrary fields (respects server rank order)", async () => {
+    // Server data intentionally has accuracy out of rank order.
+    // Client must NOT sort by accuracy — only by server rank.
+    const { useLeaderboard } = await import("../useLeaderboard");
+    const { result } = renderHook(() => useLeaderboard(), { wrapper });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    const data = result.current.data as LeaderboardEntry[];
+    // user-1 has rank 1 but accuracy 98.2; user-3 has rank 3 but accuracy 97.5
+    // If sorted by accuracy desc, order would be user-1, user-3, user-2.
+    // Correct (server-rank) order is user-1, user-2, user-3.
+    expect(data.map((e) => e.userId)).toEqual(["user-1", "user-2", "user-3"]);
+  });
+
+  it("output satisfies all protocol invariants", async () => {
+    const { useLeaderboard } = await import("../useLeaderboard");
+    const { result } = renderHook(() => useLeaderboard(), { wrapper });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    const data = result.current.data as LeaderboardEntry[];
+    const validation = validateLeaderboardInvariants(data);
+
+    expect(validation.valid).toBe(true);
+    expect(validation.violations).toEqual([]);
+  });
+
+  it("preserves entry fields other than rank", async () => {
+    const { useLeaderboard } = await import("../useLeaderboard");
+    const { result } = renderHook(() => useLeaderboard(), { wrapper });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    const data = result.current.data as LeaderboardEntry[];
+    const alice = data.find((e) => e.userId === "user-1");
+
+    expect(alice).toEqual({
+      rank: 1,
+      userId: "user-1",
+      username: "Alice",
+      totalVerifications: 10,
+      accuracy: 98.2,
+      totalStaked: 12400,
+      totalEarned: 850,
+    });
+  });
+});

--- a/src/hooks/useLeaderboard.ts
+++ b/src/hooks/useLeaderboard.ts
@@ -1,11 +1,19 @@
 // src/hooks/useLeaderboard.ts
-import { useQuery } from '@tanstack/react-query';
-import { queryKeys } from '../app/queries/queryKeys';
-import { fetchLeaderboard } from '../app/api/leaderboard.api';
+import { useQuery } from "@tanstack/react-query";
+import { queryKeys } from "../app/queries/queryKeys";
+import { fetchLeaderboard } from "../app/api/leaderboard.api";
+import { sortAndNormalizeLeaderboard } from "../lib/leaderboard";
+import type { LeaderboardEntry } from "@/app/types/websocket";
 
 export const useLeaderboard = () => {
-  return useQuery(queryKeys.leaderboard, fetchLeaderboard, {
+  return useQuery<LeaderboardEntry[]>({
+    queryKey: queryKeys.leaderboard,
+    queryFn: fetchLeaderboard,
     staleTime: 1000 * 60 * 10, // 10 min
     refetchInterval: 1000 * 60 * 5, // auto-refresh every 5 min
+    // The server is the source of truth for ranking. We only enforce protocol
+    // invariants (sort by server rank + normalize dense ranks) on the client
+    // without re-sorting by arbitrary fields.
+    select: (data: LeaderboardEntry[]) => sortAndNormalizeLeaderboard(data),
   });
 };

--- a/src/hooks/useRealtimeData.ts
+++ b/src/hooks/useRealtimeData.ts
@@ -15,6 +15,7 @@ import type {
   DisputeResolvedEvent,
   LeaderboardUpdatedEvent,
 } from '@/app/types/websocket';
+import { sortAndNormalizeLeaderboard } from '@/lib/leaderboard';
 
 /**
  * Hook that integrates WebSocket events with TanStack Query cache
@@ -147,8 +148,12 @@ export function useRealtimeData() {
   // Handle leaderboard updated events
   const handleLeaderboardUpdated = useCallback(
     (payload: LeaderboardUpdatedEvent) => {
-      // Directly update leaderboard cache
-      queryClient.setQueryData(queryKeys.leaderboard, payload.rankings);
+      // Normalize real-time rankings (sort by server rank + dense ranks)
+      // before writing to the cache so protocol invariants always hold.
+      queryClient.setQueryData(
+        queryKeys.leaderboard,
+        sortAndNormalizeLeaderboard(payload.rankings)
+      );
     },
     [queryClient]
   );
@@ -196,7 +201,10 @@ export function useRealtimeLeaderboard() {
     if (!isConnected) return;
 
     const unsubscribe = subscribe('LEADERBOARD_UPDATED', (payload) => {
-      queryClient.setQueryData(queryKeys.leaderboard, payload.rankings);
+      queryClient.setQueryData(
+        queryKeys.leaderboard,
+        sortAndNormalizeLeaderboard(payload.rankings)
+      );
     });
 
     return () => unsubscribe?.();

--- a/src/lib/__tests__/leaderboard.test.ts
+++ b/src/lib/__tests__/leaderboard.test.ts
@@ -1,0 +1,306 @@
+import {
+  sortLeaderboardByRank,
+  normalizeRanks,
+  sortAndNormalizeLeaderboard,
+  validateLeaderboardInvariants,
+  LEADERBOARD_INVARIANTS,
+} from '../leaderboard';
+import type { LeaderboardEntry } from '@/app/types/websocket';
+
+const createEntry = (overrides: Partial<LeaderboardEntry> = {}): LeaderboardEntry => ({
+  rank: 1,
+  userId: 'user-1',
+  username: 'Alice',
+  totalVerifications: 10,
+  accuracy: 95,
+  totalStaked: 1000,
+  totalEarned: 500,
+  ...overrides,
+});
+
+const validEntries: LeaderboardEntry[] = [
+  createEntry({ rank: 1, userId: 'user-1', username: 'Alice' }),
+  createEntry({ rank: 2, userId: 'user-2', username: 'Bob' }),
+  createEntry({ rank: 3, userId: 'user-3', username: 'Carol' }),
+];
+
+describe('leaderboard utilities', () => {
+  describe('sortLeaderboardByRank', () => {
+    it('sorts entries by rank ascending', () => {
+      const unsorted = [
+        createEntry({ rank: 3, userId: 'user-3' }),
+        createEntry({ rank: 1, userId: 'user-1' }),
+        createEntry({ rank: 2, userId: 'user-2' }),
+      ];
+
+      const result = sortLeaderboardByRank(unsorted);
+
+      expect(result.map((e) => e.rank)).toEqual([1, 2, 3]);
+    });
+
+    it('does not mutate the original array', () => {
+      const original = [
+        createEntry({ rank: 3, userId: 'user-3' }),
+        createEntry({ rank: 1, userId: 'user-1' }),
+      ];
+
+      const originalCopy = [...original];
+      sortLeaderboardByRank(original);
+
+      expect(original).toEqual(originalCopy);
+    });
+
+    it('preserves relative order for equal ranks (stable sort)', () => {
+      const entries = [
+        createEntry({ rank: 1, userId: 'user-a', username: 'A' }),
+        createEntry({ rank: 1, userId: 'user-b', username: 'B' }),
+        createEntry({ rank: 1, userId: 'user-c', username: 'C' }),
+      ];
+
+      const result = sortLeaderboardByRank(entries);
+
+      expect(result.map((e) => e.userId)).toEqual(['user-a', 'user-b', 'user-c']);
+    });
+
+    it('returns empty array for empty input', () => {
+      expect(sortLeaderboardByRank([])).toEqual([]);
+    });
+  });
+
+  describe('normalizeRanks', () => {
+    it('assigns dense sequential ranks starting at 1', () => {
+      const entries = [
+        createEntry({ rank: 5, userId: 'user-1' }),
+        createEntry({ rank: 10, userId: 'user-2' }),
+        createEntry({ rank: 99, userId: 'user-3' }),
+      ];
+
+      const result = normalizeRanks(entries);
+
+      expect(result.map((e) => e.rank)).toEqual([1, 2, 3]);
+    });
+
+    it('preserves other fields while only changing rank', () => {
+      const entries = [
+        createEntry({ rank: 7, userId: 'user-1', username: 'Alice', accuracy: 90 }),
+      ];
+
+      const result = normalizeRanks(entries);
+
+      expect(result[0]).toEqual({
+        ...entries[0],
+        rank: 1,
+      });
+    });
+
+    it('does not mutate the original entries', () => {
+      const entries = [createEntry({ rank: 5, userId: 'user-1' })];
+
+      normalizeRanks(entries);
+
+      expect(entries[0].rank).toBe(5);
+    });
+  });
+
+  describe('sortAndNormalizeLeaderboard', () => {
+    it('sorts by rank and normalizes to dense ranks', () => {
+      const entries = [
+        createEntry({ rank: 10, userId: 'user-3' }),
+        createEntry({ rank: 2, userId: 'user-1' }),
+        createEntry({ rank: 5, userId: 'user-2' }),
+      ];
+
+      const result = sortAndNormalizeLeaderboard(entries);
+
+      expect(result.map((e) => e.rank)).toEqual([1, 2, 3]);
+      expect(result.map((e) => e.userId)).toEqual(['user-1', 'user-2', 'user-3']);
+    });
+
+    it('produces output that passes all invariants', () => {
+      const entries = [
+        createEntry({ rank: 7, userId: 'user-3' }),
+        createEntry({ rank: 1, userId: 'user-1' }),
+        createEntry({ rank: 4, userId: 'user-2' }),
+      ];
+
+      const result = sortAndNormalizeLeaderboard(entries);
+      const validation = validateLeaderboardInvariants(result);
+
+      expect(validation.valid).toBe(true);
+      expect(validation.violations).toEqual([]);
+    });
+  });
+
+  describe('validateLeaderboardInvariants', () => {
+    it('returns valid=true for a correct leaderboard', () => {
+      const validation = validateLeaderboardInvariants(validEntries);
+
+      expect(validation.valid).toBe(true);
+      expect(validation.violations).toEqual([]);
+    });
+
+    it('returns valid=true for an empty leaderboard', () => {
+      const validation = validateLeaderboardInvariants([]);
+
+      expect(validation.valid).toBe(true);
+    });
+
+    it('detects SORT_BY_RANK violation', () => {
+      const entries = [
+        createEntry({ rank: 1, userId: 'user-1' }),
+        createEntry({ rank: 3, userId: 'user-2' }),
+        createEntry({ rank: 2, userId: 'user-3' }),
+      ];
+
+      const validation = validateLeaderboardInvariants(entries);
+
+      expect(validation.valid).toBe(false);
+      expect(validation.violations).toContain(LEADERBOARD_INVARIANTS.SORT_BY_RANK);
+    });
+
+    it('detects RANK_SEQUENTIAL violation for gaps', () => {
+      const entries = [
+        createEntry({ rank: 1, userId: 'user-1' }),
+        createEntry({ rank: 2, userId: 'user-2' }),
+        createEntry({ rank: 5, userId: 'user-3' }),
+      ];
+
+      const validation = validateLeaderboardInvariants(entries);
+
+      expect(validation.valid).toBe(false);
+      expect(validation.violations).toContain(LEADERBOARD_INVARIANTS.RANK_SEQUENTIAL);
+    });
+
+    it('detects RANK_SEQUENTIAL violation when not starting at 1', () => {
+      const entries = [
+        createEntry({ rank: 2, userId: 'user-1' }),
+        createEntry({ rank: 3, userId: 'user-2' }),
+      ];
+
+      const validation = validateLeaderboardInvariants(entries);
+
+      expect(validation.valid).toBe(false);
+      expect(validation.violations).toContain(LEADERBOARD_INVARIANTS.RANK_SEQUENTIAL);
+    });
+
+    it('detects RANK_UNIQUE violation', () => {
+      const entries = [
+        createEntry({ rank: 1, userId: 'user-1' }),
+        createEntry({ rank: 1, userId: 'user-2' }),
+        createEntry({ rank: 2, userId: 'user-3' }),
+      ];
+
+      const validation = validateLeaderboardInvariants(entries);
+
+      expect(validation.valid).toBe(false);
+      expect(validation.violations).toContain(LEADERBOARD_INVARIANTS.RANK_UNIQUE);
+    });
+
+    it('detects USER_UNIQUE violation', () => {
+      const entries = [
+        createEntry({ rank: 1, userId: 'user-1' }),
+        createEntry({ rank: 2, userId: 'user-1' }),
+        createEntry({ rank: 3, userId: 'user-3' }),
+      ];
+
+      const validation = validateLeaderboardInvariants(entries);
+
+      expect(validation.valid).toBe(false);
+      expect(validation.violations).toContain(LEADERBOARD_INVARIANTS.USER_UNIQUE);
+    });
+
+    it('detects NON_NEGATIVE violation for negative totalStaked', () => {
+      const entries = [
+        createEntry({ rank: 1, userId: 'user-1', totalStaked: -100 }),
+        createEntry({ rank: 2, userId: 'user-2' }),
+        createEntry({ rank: 3, userId: 'user-3' }),
+      ];
+
+      const validation = validateLeaderboardInvariants(entries);
+
+      expect(validation.valid).toBe(false);
+      expect(validation.violations).toContain(LEADERBOARD_INVARIANTS.NON_NEGATIVE);
+    });
+
+    it('detects NON_NEGATIVE violation for negative totalEarned', () => {
+      const entries = [
+        createEntry({ rank: 1, userId: 'user-1' }),
+        createEntry({ rank: 2, userId: 'user-2', totalEarned: -5 }),
+        createEntry({ rank: 3, userId: 'user-3' }),
+      ];
+
+      const validation = validateLeaderboardInvariants(entries);
+
+      expect(validation.valid).toBe(false);
+      expect(validation.violations).toContain(LEADERBOARD_INVARIANTS.NON_NEGATIVE);
+    });
+
+    it('detects ACCURACY_RANGE violation for accuracy > 100', () => {
+      const entries = [
+        createEntry({ rank: 1, userId: 'user-1', accuracy: 150 }),
+        createEntry({ rank: 2, userId: 'user-2' }),
+        createEntry({ rank: 3, userId: 'user-3' }),
+      ];
+
+      const validation = validateLeaderboardInvariants(entries);
+
+      expect(validation.valid).toBe(false);
+      expect(validation.violations).toContain(LEADERBOARD_INVARIANTS.ACCURACY_RANGE);
+    });
+
+    it('detects ACCURACY_RANGE violation for negative accuracy', () => {
+      const entries = [
+        createEntry({ rank: 1, userId: 'user-1' }),
+        createEntry({ rank: 2, userId: 'user-2', accuracy: -1 }),
+        createEntry({ rank: 3, userId: 'user-3' }),
+      ];
+
+      const validation = validateLeaderboardInvariants(entries);
+
+      expect(validation.valid).toBe(false);
+      expect(validation.violations).toContain(LEADERBOARD_INVARIANTS.ACCURACY_RANGE);
+    });
+
+    it('de-duplicates violations', () => {
+      // Multiple duplicate ranks should only report RANK_UNIQUE once
+      const entries = [
+        createEntry({ rank: 1, userId: 'user-1' }),
+        createEntry({ rank: 1, userId: 'user-2' }),
+        createEntry({ rank: 1, userId: 'user-3' }),
+      ];
+
+      const validation = validateLeaderboardInvariants(entries);
+
+      const rankUniqueCount = validation.violations.filter(
+        (v) => v === LEADERBOARD_INVARIANTS.RANK_UNIQUE
+      ).length;
+      expect(rankUniqueCount).toBe(1);
+    });
+  });
+
+  describe('protocol invariant integration', () => {
+    it('sortAndNormalizeLeaderboard output always satisfies all invariants', () => {
+      // Simulate server data with non-sequential ranks
+      const serverData = [
+        createEntry({ rank: 5, userId: 'user-5', username: 'Eve' }),
+        createEntry({ rank: 1, userId: 'user-1', username: 'Alice' }),
+        createEntry({ rank: 3, userId: 'user-3', username: 'Carol' }),
+        createEntry({ rank: 2, userId: 'user-2', username: 'Bob' }),
+        createEntry({ rank: 4, userId: 'user-4', username: 'Dave' }),
+      ];
+
+      const normalized = sortAndNormalizeLeaderboard(serverData);
+      const validation = validateLeaderboardInvariants(normalized);
+
+      expect(validation.valid).toBe(true);
+      expect(normalized.map((e) => e.rank)).toEqual([1, 2, 3, 4, 5]);
+      expect(normalized.map((e) => e.userId)).toEqual([
+        'user-1',
+        'user-2',
+        'user-3',
+        'user-4',
+        'user-5',
+      ]);
+    });
+  });
+});

--- a/src/lib/leaderboard.ts
+++ b/src/lib/leaderboard.ts
@@ -1,0 +1,138 @@
+// src/lib/leaderboard.ts
+
+import type { LeaderboardEntry } from '@/app/types/websocket';
+
+/**
+ * Leaderboard protocol invariants.
+ *
+ * The server is the authoritative source for ranking. The client must NOT
+ * re-sort entries by arbitrary fields (e.g. accuracy, totalEarned) because
+ * that could diverge from the server's composite scoring. Instead, the
+ * client trusts the server-provided `rank` and only enforces the following
+ * protocol invariants:
+ *
+ *  1. SORT_BY_RANK   – entries are ordered by `rank` ascending.
+ *  2. RANK_SEQUENTIAL – ranks are dense integers starting at 1 (1, 2, 3 …).
+ *  3. RANK_UNIQUE     – no two entries share the same rank.
+ *  4. USER_UNIQUE     – no two entries share the same `userId`.
+ *  5. NON_NEGATIVE    – `totalVerifications`, `totalStaked`, `totalEarned` ≥ 0.
+ *  6. ACCURACY_RANGE  – `accuracy` ∈ [0, 100].
+ */
+export const LEADERBOARD_INVARIANTS = {
+  SORT_BY_RANK: 'SORT_BY_RANK',
+  RANK_SEQUENTIAL: 'RANK_SEQUENTIAL',
+  RANK_UNIQUE: 'RANK_UNIQUE',
+  USER_UNIQUE: 'USER_UNIQUE',
+  NON_NEGATIVE: 'NON_NEGATIVE',
+  ACCURACY_RANGE: 'ACCURACY_RANGE',
+} as const;
+
+export type LeaderboardInvariant =
+  (typeof LEADERBOARD_INVARIANTS)[keyof typeof LEADERBOARD_INVARIANTS];
+
+/**
+ * Sort leaderboard entries by server-provided `rank` (ascending).
+ *
+ * This is a stable sort: entries with equal rank preserve their original
+ * relative order so the server's intent is never contradicted.
+ */
+export function sortLeaderboardByRank(
+  entries: LeaderboardEntry[]
+): LeaderboardEntry[] {
+  return [...entries].sort((a, b) => a.rank - b.rank);
+}
+
+/**
+ * Re-assign dense sequential ranks (1, 2, 3 …) based on the current order.
+ *
+ * This is used after sorting to guarantee the `RANK_SEQUENTIAL` and
+ * `RANK_UNIQUE` invariants. The original order (and therefore the server's
+ * ranking intent) is preserved — only the numeric `rank` label is normalized.
+ */
+export function normalizeRanks(
+  entries: LeaderboardEntry[]
+): LeaderboardEntry[] {
+  return entries.map((entry, index) => ({
+    ...entry,
+    rank: index + 1,
+  }));
+}
+
+/**
+ * Sort by server rank and normalize rank labels so the result always
+ * satisfies `SORT_BY_RANK`, `RANK_SEQUENTIAL` and `RANK_UNIQUE`.
+ */
+export function sortAndNormalizeLeaderboard(
+  entries: LeaderboardEntry[]
+): LeaderboardEntry[] {
+  return normalizeRanks(sortLeaderboardByRank(entries));
+}
+
+/**
+ * Validate that a leaderboard array satisfies every protocol invariant.
+ *
+ * Returns an object describing which invariants hold. This is primarily
+ * intended for assertions in tests and for guarding real-time updates.
+ */
+export function validateLeaderboardInvariants(
+  entries: LeaderboardEntry[]
+): { valid: boolean; violations: LeaderboardInvariant[] } {
+  const violations: LeaderboardInvariant[] = [];
+
+  // SORT_BY_RANK – must be ascending by rank.
+  for (let i = 1; i < entries.length; i++) {
+    if (entries[i].rank < entries[i - 1].rank) {
+      violations.push(LEADERBOARD_INVARIANTS.SORT_BY_RANK);
+      break;
+    }
+  }
+
+  // RANK_UNIQUE & USER_UNIQUE
+  const seenRanks = new Set<number>();
+  const seenUsers = new Set<string>();
+  for (const entry of entries) {
+    if (seenRanks.has(entry.rank)) {
+      violations.push(LEADERBOARD_INVARIANTS.RANK_UNIQUE);
+    }
+    seenRanks.add(entry.rank);
+
+    if (seenUsers.has(entry.userId)) {
+      violations.push(LEADERBOARD_INVARIANTS.USER_UNIQUE);
+    }
+    seenUsers.add(entry.userId);
+  }
+
+  // RANK_SEQUENTIAL – dense integers starting at 1.
+  const expectedRanks = entries.map((_, i) => i + 1);
+  const actualRanks = entries.map((e) => e.rank);
+  if (
+    expectedRanks.length !== actualRanks.length ||
+    !expectedRanks.every((r, i) => r === actualRanks[i])
+  ) {
+    violations.push(LEADERBOARD_INVARIANTS.RANK_SEQUENTIAL);
+  }
+
+  // NON_NEGATIVE & ACCURACY_RANGE
+  for (const entry of entries) {
+    if (
+      entry.totalVerifications < 0 ||
+      entry.totalStaked < 0 ||
+      entry.totalEarned < 0
+    ) {
+      violations.push(LEADERBOARD_INVARIANTS.NON_NEGATIVE);
+      break;
+    }
+    if (entry.accuracy < 0 || entry.accuracy > 100) {
+      violations.push(LEADERBOARD_INVARIANTS.ACCURACY_RANGE);
+      break;
+    }
+  }
+
+  // De-duplicate violations while preserving order.
+  const uniqueViolations = [...new Set(violations)];
+
+  return {
+    valid: uniqueViolations.length === 0,
+    violations: uniqueViolations,
+  };
+}


### PR DESCRIPTION
…ants

- Add src/lib/leaderboard.ts with sort/normalize/validate utilities
- Server is source of truth: sort by server rank, normalize dense ranks
- Enforce protocol invariants: SORT_BY_RANK, RANK_SEQUENTIAL, RANK_UNIQUE, USER_UNIQUE, NON_NEGATIVE, ACCURACY_RANGE
- Update useLeaderboard hook to use select with sortAndNormalizeLeaderboard
- Update duplicate leaderboard.queries.ts hook with same logic
- Migrate both hooks to React Query v5 object syntax
- Normalize WebSocket LEADERBOARD_UPDATED payloads in useRealtimeData
- Fix mock handler to return proper LeaderboardEntry-shaped data
- Add 22 unit tests for leaderboard utilities
- Add 5 hook tests verifying sort order, normalization, and invariants
- All 29 leaderboard-related tests pass
closes #198 